### PR TITLE
Double event firing on modal comp fixed

### DIFF
--- a/src/components/ModalComp.vue
+++ b/src/components/ModalComp.vue
@@ -31,8 +31,6 @@
         :buttonPrice="buttonPrice"
         :buttonVariation="buttonVariation"
         :cancelTitle="cancelTitle"
-        @subscribe-click="$emit('subscribe-click')"
-        @cancel-click="$emit('cancel-click')"
         v-on="$listeners"
       >
         <template #preview>
@@ -60,7 +58,6 @@
         :text="text"
         :width="width"
         :minWidth="minWidth"
-        @confirm="$emit('confirm')"
         :confirmButtonText="confirmButtonText"
         :buttonVariation="buttonVariation"
         v-on="$listeners"

--- a/src/demos/Modals.vue
+++ b/src/demos/Modals.vue
@@ -57,25 +57,12 @@ components: {
         :text="
           'Save combining multiple windows like Streamlabels, Twitch Chat, Twitch Dashboard, Video, Streamlabs Dashboard, OBS etc into a live view.'
         "
-        >hey there</ModalComp
-      >
+      >hey there</ModalComp>
 
       <div class="s-button-container--left">
-        <Button
-          :variation="'default'"
-          :title="'modal basic1'"
-          @click="$modal.show('modal-basic')"
-        ></Button>
-        <Button
-          :variation="'default'"
-          :title="'modal basic2'"
-          @click="$modal.show('modal-basic2')"
-        ></Button>
-        <Button
-          :variation="'default'"
-          :title="'modal basic3'"
-          @click="$modal.show('modal-basic3')"
-        ></Button>
+        <Button :variation="'default'" :title="'modal basic1'" @click="$modal.show('modal-basic')"></Button>
+        <Button :variation="'default'" :title="'modal basic2'" @click="$modal.show('modal-basic2')"></Button>
+        <Button :variation="'default'" :title="'modal basic3'" @click="$modal.show('modal-basic3')"></Button>
       </div>
     </div>
 
@@ -114,8 +101,6 @@ components: {
         :subscribeText="'galazy83 donated $50.00!'"
         :subscribeMessage="'Thanks for the stream. Go CivRyan!'"
         :notes="'You may cancel your subscription at any time.'"
-        @subscribe-click="logClick('Subscribe Click')"
-        @cancel-click="logClick('cancel click')"
       ></ModalComp>
 
       <div class="button-container button-container--left">
@@ -226,7 +211,7 @@ components: {
             name is optional. if you need specific name for the modal, use name
             prop. Also don't forget to change $modal.show() to the name you set
             as prop.
-            <br />ex.
+            <br>ex.
             <code>:name="'modal-basic2'"</code>
             <code>$modal.show('modal-basic2')</code>
           </td>
@@ -317,7 +302,8 @@ components: {
             Pass in
             <code>action</code> if it's a confirmation that doesn't warrant a
             warning (only in Modal Confirmation). In Modal Subscribe default is
-            <code>subscribe</code>. Can be set to <code>paypal</code> and
+            <code>subscribe</code>. Can be set to
+            <code>paypal</code> and
             <code>paypal-blue</code> variations.
           </td>
         </tr>
@@ -338,7 +324,8 @@ components: {
           <td>boolean</td>
           <td>true</td>
           <td>
-            Displays <code>Pro</code> badge in modal header (only in Modal
+            Displays
+            <code>Pro</code> badge in modal header (only in Modal
             Subscribe).
           </td>
         </tr>
@@ -349,10 +336,10 @@ components: {
           <td>
             Allows for custom preview above modal text. Uses
             <code>preview</code> slot.
-            <code
-              >&lt;template #preview&gt;Custom Preview
-              HTML&lt;template&gt;</code
-            >
+            <code>
+              &lt;template #preview&gt;Custom Preview
+              HTML&lt;template&gt;
+            </code>
             (only in Modal Subscribe).
           </td>
         </tr>
@@ -386,9 +373,5 @@ import Button from "./../components/Button.vue";
     Button
   }
 })
-export default class Modals extends Vue {
-  logClick(string: string){
-    console.log(string);
-  }
-}
+export default class Modals extends Vue {}
 </script>

--- a/src/demos/Modals.vue
+++ b/src/demos/Modals.vue
@@ -114,6 +114,8 @@ components: {
         :subscribeText="'galazy83 donated $50.00!'"
         :subscribeMessage="'Thanks for the stream. Go CivRyan!'"
         :notes="'You may cancel your subscription at any time.'"
+        @subscribe-click="logClick('Subscribe Click')"
+        @cancel-click="logClick('cancel click')"
       ></ModalComp>
 
       <div class="button-container button-container--left">
@@ -384,5 +386,9 @@ import Button from "./../components/Button.vue";
     Button
   }
 })
-export default class Modals extends Vue {}
+export default class Modals extends Vue {
+  logClick(string: string){
+    console.log(string);
+  }
+}
 </script>


### PR DESCRIPTION
- v-on=$listeners already passes the events no need to redeclare inside of modal-comp