### PR TITLE
Add image-picker-input to system.js

### DIFF
--- a/src/system.js
+++ b/src/system.js
@@ -24,6 +24,7 @@ import FormGroupV from "./components/FormGroupV.vue";
 import Guard from "./components/Guard.vue";
 import HelloWorld from "./components/HelloWorld.vue";
 import ImagePicker from "./components/ImagePicker.vue";
+import ImagePickerInput from "./components/ImagePickerInput.vue";
 import ItemGrid from "./components/ItemGrid.vue";
 import Loading from "./components/Loading.vue";
 import ModalBasic from "./components/ModalBasic.vue";
@@ -79,6 +80,7 @@ export {
   Guard,
   HelloWorld,
   ImagePicker,
+  ImagePickerInput,
   ItemGrid,
   Loading,
   ModalBasic,


### PR DESCRIPTION
- ImagePickerInput was missing in system.js so that I could not use it for sl.com