### PR TITLE
feat(button): update the logic of slobs dl button

### DIFF
--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -19,9 +19,11 @@
   >
     <span v-if="!$slots.custom">
       <span>
-        <span v-if="variation === 'prime-simple' && this.primeTitle">{{
+        <span v-if="variation === 'prime-simple' && this.primeTitle">
+          {{
           primeTitle
-        }}</span>
+          }}
+        </span>
         <span v-else-if="variation === 'prime-simple'" class="prime-simple">
           Free with
           <span class="prime-simple__bold">Prime</span>
@@ -32,32 +34,25 @@
         </i>
         {{ title }}
       </span>
-      <span v-if="description" class="s-button__description">{{
+      <span v-if="description" class="s-button__description">
+        {{
         description
-      }}</span>
-      <i
-        v-if="iconClass && iconPosition === 'right'"
-        :class="['icon--right', iconClass]"
-      ></i>
+        }}
+      </span>
+      <i v-if="iconClass && iconPosition === 'right'" :class="['icon--right', iconClass]"></i>
     </span>
 
     <slot name="custom"></slot>
     <i v-if="variation === 'slobs-download'" class="icon-windows"></i>
     <span v-if="price">{{ price }}</span>
-    <div
-      v-if="variation === 'slobs-download-landing'"
-      class="slobs-download-landing"
-    >
+    <div v-if="variation === 'slobs-download-landing'" class="slobs-download-landing">
       <div class="slobs-download-landing__upper">
-        <i
-          class="slobs-download-landing__icon"
-          :class="osType === 'windows' ? 'icon-windows' : 'icon-app-store'"
-        />
+        <i class="slobs-download-landing__icon" :class="slobsDownloadIconClass" />
         <p class="slobs-download-landing__title">{{ slobsDownloadTitle }}</p>
       </div>
       <div class="slobs-download-landing__bottom">
         <p class="slobs-download-landing__subtitle">
-          <slot name="slobs-download-detail" />
+          <span v-for="text in slobsDownloadText" :key="text" v-text="text"></span>
         </p>
       </div>
     </div>
@@ -180,9 +175,7 @@ export default class Button extends Vue {
   };
 
   @Prop({ default: "windows" })
-  osType!: {
-    type: String;
-  };
+  osType!: string;
 
   private rippleStartX = 0;
   private rippleStartY = 0;
@@ -222,6 +215,20 @@ export default class Button extends Vue {
     }
 
     return classes.join(" ");
+  }
+
+  get slobsDownloadIconClass() {
+    return this.osType === "windows" ? "icon-windows" : "icon-app-store";
+  }
+
+  get slobsDownloadText() {
+    const tests: any = [];
+
+    tests.push("Free");
+    tests.push(this.osType === "windows" ? "Win" : "macOS 10.14+");
+    tests.push(this.osType === "windows" ? "~240MB" : "309MB");
+
+    return tests;
   }
 
   get buttonStyle() {
@@ -572,6 +579,14 @@ export default class Button extends Vue {
     grid-column-gap: 12px;
     .margin-bottom(0);
     word-spacing: 8px;
+
+    span {
+      text-transform: none;
+
+      &:nth-child(2) {
+        word-spacing: 1px;
+      }
+    }
   }
 }
 

--- a/src/demos/Buttons.vue
+++ b/src/demos/Buttons.vue
@@ -4,7 +4,9 @@
       <h1>Buttons</h1>
       <p>
         Our button component is super flexible. It can act as type
-        <code>button</code>, <code>a</code> tag or <code>router-link</code>.
+        <code>button</code>,
+        <code>a</code> tag or
+        <code>router-link</code>.
         Please note that you may need to use 'ButtonInput' rather than 'Button'
         to avoid issues.
       </p>
@@ -32,17 +34,9 @@ components: {
                 @click="reportSlobsDownloads"
               />
 
-              <Button
-                variation="action"
-                title="Action"
-                @click="buttonActionClick"
-              />
+              <Button variation="action" title="Action" @click="buttonActionClick" />
 
-              <Button
-                variation="warning"
-                title="Warning"
-                @click="buttonActionClick"
-              />
+              <Button variation="warning" title="Warning" @click="buttonActionClick" />
 
               <Button
                 variation="default"
@@ -59,12 +53,7 @@ components: {
                 @click="buttonActionClick"
               />
 
-              <Button
-                variation="prime"
-                title="Join Prime"
-                icon="prime"
-                @click="buttonActionClick"
-              />
+              <Button variation="prime" title="Join Prime" icon="prime" @click="buttonActionClick" />
 
               <Button
                 variation="prime-white"
@@ -89,23 +78,11 @@ components: {
         <DemoSection title="Disabled" :code="demoCode">
           <template #components>
             <div class="s-button-container s-button-container--left">
-              <Button
-                :variation="'default'"
-                :state="'disabled'"
-                :title="'Default'"
-              />
+              <Button :variation="'default'" :state="'disabled'" :title="'Default'" />
 
-              <Button
-                :variation="'action'"
-                :state="'disabled'"
-                :title="'Action'"
-              />
+              <Button :variation="'action'" :state="'disabled'" :title="'Action'" />
 
-              <Button
-                :variation="'warning'"
-                :state="'disabled'"
-                :title="'Warning'"
-              />
+              <Button :variation="'warning'" :state="'disabled'" :title="'Warning'" />
 
               <Button
                 :variation="'default'"
@@ -123,23 +100,11 @@ components: {
         <DemoSection title="Focus" :code="demoCode">
           <template #components>
             <div class="s-button-container s-button-container--left">
-              <Button
-                :variation="'default'"
-                :state="'focused'"
-                :title="'Default'"
-              />
+              <Button :variation="'default'" :state="'focused'" :title="'Default'" />
 
-              <Button
-                :variation="'action'"
-                :state="'focused'"
-                :title="'Action'"
-              />
+              <Button :variation="'action'" :state="'focused'" :title="'Action'" />
 
-              <Button
-                :variation="'warning'"
-                :state="'focused'"
-                :title="'Warning'"
-              />
+              <Button :variation="'warning'" :state="'focused'" :title="'Warning'" />
 
               <Button
                 :variation="'default'"
@@ -157,23 +122,11 @@ components: {
         <DemoSection title="Loading" :code="demoCode">
           <template #components>
             <div class="s-button-container s-button-container--left">
-              <Button
-                :variation="'default'"
-                :state="'loading'"
-                :title="'Default'"
-              />
+              <Button :variation="'default'" :state="'loading'" :title="'Default'" />
 
-              <Button
-                :variation="'action'"
-                :state="'loading'"
-                :title="'Action'"
-              />
+              <Button :variation="'action'" :state="'loading'" :title="'Action'" />
 
-              <Button
-                :variation="'warning'"
-                :state="'loading'"
-                :title="'Warning'"
-              />
+              <Button :variation="'warning'" :state="'loading'" :title="'Warning'" />
 
               <Button
                 :variation="'default'"
@@ -210,26 +163,11 @@ components: {
       <DemoSection title="Small Buttons" :code="demoCode">
         <template #components>
           <div class="s-button-container s-button-container--left">
-            <Button
-              :type="'button'"
-              :size="'small'"
-              :variation="'default'"
-              :title="'Default'"
-            />
+            <Button :type="'button'" :size="'small'" :variation="'default'" :title="'Default'" />
 
-            <Button
-              :type="'button'"
-              :size="'small'"
-              :variation="'action'"
-              :title="'Action'"
-            />
+            <Button :type="'button'" :size="'small'" :variation="'action'" :title="'Action'" />
 
-            <Button
-              :type="'button'"
-              :size="'small'"
-              :variation="'warning'"
-              :title="'Warning'"
-            />
+            <Button :type="'button'" :size="'small'" :variation="'warning'" :title="'Warning'" />
 
             <Button
               :type="'button'"
@@ -239,11 +177,7 @@ components: {
               :icon="'image'"
             />
 
-            <Button
-              :variation="'rewards-standard'"
-              :size="'small'"
-              :title="'Rewards'"
-            />
+            <Button :variation="'rewards-standard'" :size="'small'" :title="'Rewards'" />
           </div>
         </template>
       </DemoSection>
@@ -258,26 +192,11 @@ components: {
       <DemoSection title="Large Buttons" :code="demoCode">
         <template #components>
           <div class="s-button-container s-button-container--left">
-            <Button
-              :type="'button'"
-              :size="'large'"
-              :variation="'default'"
-              :title="'Default'"
-            />
+            <Button :type="'button'" :size="'large'" :variation="'default'" :title="'Default'" />
 
-            <Button
-              :type="'button'"
-              :size="'large'"
-              :variation="'action'"
-              :title="'Action'"
-            />
+            <Button :type="'button'" :size="'large'" :variation="'action'" :title="'Action'" />
 
-            <Button
-              :type="'button'"
-              :size="'large'"
-              :variation="'warning'"
-              :title="'Warning'"
-            />
+            <Button :type="'button'" :size="'large'" :variation="'warning'" :title="'Warning'" />
 
             <Button
               :type="'button'"
@@ -287,12 +206,7 @@ components: {
               :icon="'image'"
             />
 
-            <Button
-              :size="'large'"
-              :variation="'prime'"
-              :title="'Join Prime'"
-              :icon="'prime'"
-            />
+            <Button :size="'large'" :variation="'prime'" :title="'Join Prime'" :icon="'prime'" />
             <Button
               :size="'large'"
               :variation="'prime-white'"
@@ -311,26 +225,11 @@ components: {
       <DemoSection title="Fixed Width Buttons" :code="demoCode">
         <template #components>
           <div class="s-button-container s-button-container--left">
-            <Button
-              type="button"
-              size="fixed-width"
-              variation="default"
-              title="Default"
-            />
+            <Button type="button" size="fixed-width" variation="default" title="Default" />
 
-            <Button
-              type="button"
-              size="fixed-width"
-              variation="action"
-              title="Action"
-            />
+            <Button type="button" size="fixed-width" variation="action" title="Action" />
 
-            <Button
-              type="button"
-              size="fixed-width"
-              variation="warning"
-              title="Warning"
-            />
+            <Button type="button" size="fixed-width" variation="warning" title="Warning" />
 
             <Button
               type="button"
@@ -351,11 +250,7 @@ components: {
         <p>Used within cards and panels in the Dashboard.</p>
         <DemoSection title="Default" :code="demoCode">
           <template #components>
-            <Button
-              size="full-width"
-              variation="default"
-              title="Start Giveaway"
-            />
+            <Button size="full-width" variation="default" title="Start Giveaway" />
           </template>
         </DemoSection>
       </div>
@@ -375,11 +270,7 @@ components: {
         <p>Used on the Tip Page for Subscribing to Pro.</p>
         <DemoSection title="Paypal" :code="demoCode">
           <template #components>
-            <Button
-              variation="paypal"
-              title="Subscribe with PayPal"
-              price="$4.99"
-            />
+            <Button variation="paypal" title="Subscribe with PayPal" price="$4.99" />
           </template>
         </DemoSection>
       </div>
@@ -390,15 +281,9 @@ components: {
         <DemoSection title="Download" :code="demoCode">
           <template #components>
             <div class="s-button-container s-button-container--left">
-              <Button
-                variation="slobs-download"
-                title="Download Streamlabs OBS"
-              />
-              <Button variation="slobs-download-landing" osType="mac">
-                <template slot="slobs-download-detail"
-                  >Free Mac ~240MB</template
-                >
-              </Button>
+              <Button variation="slobs-download" title="Download Streamlabs OBS" />
+              <Button variation="slobs-download-landing" osType="windows"></Button>
+              <Button variation="slobs-download-landing" osType="mac"></Button>
             </div>
           </template>
         </DemoSection>
@@ -410,47 +295,17 @@ components: {
       <DemoSection title="Square Buttons" :code="demoCode">
         <template #components>
           <div class="s-button-container s-button-container--left">
-            <Button
-              type="button"
-              size="square"
-              variation="default"
-              icon="add"
-            />
+            <Button type="button" size="square" variation="default" icon="add" />
 
-            <Button
-              type="button"
-              size="square"
-              variation="default"
-              icon="subtract"
-            />
+            <Button type="button" size="square" variation="default" icon="subtract" />
 
-            <Button
-              type="button"
-              variation="facebook"
-              size="square"
-              icon="facebook"
-            />
+            <Button type="button" variation="facebook" size="square" icon="facebook" />
 
-            <Button
-              type="button"
-              variation="periscope"
-              size="square"
-              icon="periscope"
-            />
+            <Button type="button" variation="periscope" size="square" icon="periscope" />
 
-            <Button
-              type="button"
-              variation="mixer"
-              size="square"
-              icon="mixer"
-            />
+            <Button type="button" variation="mixer" size="square" icon="mixer" />
 
-            <Button
-              type="button"
-              variation="picarto"
-              size="square"
-              icon="picarto"
-            />
+            <Button type="button" variation="picarto" size="square" icon="picarto" />
           </div>
         </template>
       </DemoSection>
@@ -462,11 +317,7 @@ components: {
 
       <DemoSection title="Navigation Buttons" :code="demoCode">
         <template #components>
-          <Button
-            variation="navigation"
-            icon="back-alt"
-            title="Back to Listings"
-          />
+          <Button variation="navigation" icon="back-alt" title="Back to Listings" />
         </template>
       </DemoSection>
     </div>
@@ -501,7 +352,8 @@ components: {
           <td>null</td>
           <td>
             Emits a click function. If you are using an event modifier such as
-            <code>prevent</code>, use <code>native</code>. For example
+            <code>prevent</code>, use
+            <code>native</code>. For example
             <code>@click.native.prevent</code>.
           </td>
         </tr>
@@ -572,7 +424,8 @@ components: {
           <td>null</td>
           <td>
             Used if the the
-            <code>type</code> is an <code>a</code> element (links).
+            <code>type</code> is an
+            <code>a</code> element (links).
           </td>
         </tr>
         <tr>
@@ -581,7 +434,9 @@ components: {
           <td>standard</td>
           <td>
             Size of the button. Options are
-            <code>small</code>, <code>large</code>, <code>square</code>,
+            <code>small</code>,
+            <code>large</code>,
+            <code>square</code>,
             <code>fixed-width</code>, and
             <code>full-width</code>
           </td>
@@ -592,7 +447,9 @@ components: {
           <td>null</td>
           <td>
             State of the button. Options are
-            <code>hover</code>, <code>focus</code>, <code>loading</code> and
+            <code>hover</code>,
+            <code>focus</code>,
+            <code>loading</code> and
             <code>disabled</code>.
           </td>
         </tr>
@@ -608,7 +465,8 @@ components: {
           <td>null</td>
           <td>
             Used if the the
-            <code>type</code> is a <code>router-link</code>. Define the path.
+            <code>type</code> is a
+            <code>router-link</code>. Define the path.
           </td>
         </tr>
         <tr>
@@ -617,7 +475,8 @@ components: {
           <td>button</td>
           <td>
             What type of element the component is. Options are
-            <code>button</code>, <code>a</code>,
+            <code>button</code>,
+            <code>a</code>,
             <code>router-link</code>
           </td>
         </tr>
@@ -629,7 +488,9 @@ components: {
             Used to set different targets for
             <code>a</code>
             links,
-            <code>_self</code>, <code>_blank</code>, <code>_parent</code>,
+            <code>_self</code>,
+            <code>_blank</code>,
+            <code>_parent</code>,
             <code>_top</code>
           </td>
         </tr>
@@ -639,7 +500,8 @@ components: {
           <td>null</td>
           <td>
             You can use this prop when you set variation as
-            <code>prime</code>. Option is only <code>white</code>.
+            <code>prime</code>. Option is only
+            <code>white</code>.
           </td>
         </tr>
         <tr>
@@ -658,16 +520,28 @@ components: {
           <td>default</td>
           <td>
             The variation style of a button. Primary options are
-            <code>default</code>, <code>action</code>, <code>prime</code> and
-            <code>warning</code>. Other options are <code>subscribe</code>,
-            <code>paypal</code>, <code>download</code>, and
+            <code>default</code>,
+            <code>action</code>,
+            <code>prime</code> and
+            <code>warning</code>. Other options are
+            <code>subscribe</code>,
+            <code>paypal</code>,
+            <code>download</code>, and
             <code>navigation</code>. Reward options are
-            <code>rewards-standard</code>, <code>rewards-silver</code>,
-            <code>rewards-gold</code>, <code>rewards-platinum</code>,
-            <code>rewards-diamond</code>, and <code>rewards-legend</code>.
-            Platform options are <code>facebook</code>, <code>mixer</code>,
-            <code>twitch</code>, <code>youtube</code>, <code>periscope</code>,
-            <code>picarto</code>and <code>paypal-blue</code>.
+            <code>rewards-standard</code>,
+            <code>rewards-silver</code>,
+            <code>rewards-gold</code>,
+            <code>rewards-platinum</code>,
+            <code>rewards-diamond</code>, and
+            <code>rewards-legend</code>.
+            Platform options are
+            <code>facebook</code>,
+            <code>mixer</code>,
+            <code>twitch</code>,
+            <code>youtube</code>,
+            <code>periscope</code>,
+            <code>picarto</code>and
+            <code>paypal-blue</code>.
           </td>
         </tr>
         <tr>
@@ -682,7 +556,8 @@ components: {
           <td>windows</td>
           <td>
             Used for slobs download landing button icon. Options are
-            <code>windows</code> and <code>mac</code>.
+            <code>windows</code> and
+            <code>mac</code>.
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
- was asked to add the recommended version for the slobs download button of mac. 
- updated the logic about `variation="slobs-download-landing"`. With this change, we just need to set `osType` as props then either windows or mac slobs download button will appear.