### PR TITLE
feat: add an alt in thumbnail for SEO improvement

### DIFF
--- a/src/components/CallToAction.vue
+++ b/src/components/CallToAction.vue
@@ -10,15 +10,11 @@
       :class="callToActionThumbMq"
       :style="callToActionThumb"
     >
-      <img :src="thumbnail" />
+      <img :src="thumbnail" :alt="thumbnailAlt" />
     </div>
     <div class="s-call-to-action__description" :class="callToActionDescMq">
-      <div class="s-title" :class="titleMq" :style="callToActiontitleColor">
-        {{ title }}
-      </div>
-      <div class="s-subtitle" :style="callToActionSubTitleColor">
-        {{ description }}
-      </div>
+      <div class="s-title" :class="titleMq" :style="callToActiontitleColor">{{ title }}</div>
+      <div class="s-subtitle" :style="callToActionSubTitleColor">{{ description }}</div>
     </div>
     <slot v-if="customButtonSlot"></slot>
     <div v-else class="s-button-container s-button-container--right">
@@ -98,6 +94,9 @@ export default class CallToAction extends Vue {
 
   @Prop()
   thumbnailBg!: String;
+
+  @Prop({ default: "Get started by downloading Streamlabs OBS" })
+  thumbnailAlt!: String;
 
   @Prop({ default: "Get started by downloading Streamlabs OBS" })
   title!: String;

--- a/src/demos/CallToActions.vue
+++ b/src/demos/CallToActions.vue
@@ -29,7 +29,7 @@ components: {
         <DemoSection title="Custom" :code="demoCode">
           <template #components>
             <CallToAction
-              bgColor="#31c3a2"
+              bgcolor="#31c3a2"
               titleColor="#ffffff"
               subTitleColor="#ffffff"
               :thumbnail="require('./../assets/imgs/logo.svg')"
@@ -40,7 +40,7 @@ components: {
               description="A Custom Description"
               buttonVariation="default"
               buttonTitle="Click Me"
-              buttonDescription=""
+              buttonDescription
               buttonTag="a"
               buttonHref="https://google.com"
               buttonBg="#ffffff"
@@ -126,9 +126,7 @@ components: {
             <td>thumbnailBg</td>
             <td>String</td>
             <td>#31C3A2</td>
-            <td>
-              A Thumbnail background color, default color is @teal (#31C3A2)
-            </td>
+            <td>A Thumbnail background color, default color is @teal (#31C3A2)</td>
           </tr>
 
           <tr>
@@ -143,6 +141,13 @@ components: {
             <td>Number</td>
             <td>80</td>
             <td>A Thumbnail height</td>
+          </tr>
+
+          <tr>
+            <td>thumbnailAlt</td>
+            <td>String</td>
+            <td>Get started by downloading Streamlabs OBS</td>
+            <td>A Thumbnail alt</td>
           </tr>
 
           <tr>
@@ -200,7 +205,8 @@ components: {
             <td>null</td>
             <td>
               Used if the the
-              <code>type</code> is an <code>a</code> element (links).
+              <code>type</code> is an
+              <code>a</code> element (links).
             </td>
           </tr>
           <tr>
@@ -209,7 +215,8 @@ components: {
             <td>null</td>
             <td>
               Used if the the
-              <code>type</code> is a <code>router-link</code>. Define the path.
+              <code>type</code> is a
+              <code>router-link</code>. Define the path.
             </td>
           </tr>
           <tr>
@@ -218,7 +225,8 @@ components: {
             <td>null</td>
             <td>
               What type of element the component is. Options are
-              <code>button</code>, <code>a</code>,
+              <code>button</code>,
+              <code>a</code>,
               <code>router-link</code>
             </td>
           </tr>


### PR DESCRIPTION
To improve SEO in Lighthouse, Google Chrome Devtool, An alt attribute is added to an image element.