### PR TITLE
feat: create the reusable banner using slots

### DIFF
--- a/src/components/BannerIntroduction.vue
+++ b/src/components/BannerIntroduction.vue
@@ -28,8 +28,16 @@ export default class BannerIntroduction extends Vue {
 <style lang="less">
 @import (reference) "./../styles/Imports";
 
+.night {
+  .s-banner-introduction {
+    &__description {
+      color: @white;
+    }
+  }
+}
+
 .s-banner-introduction {
-  box-shadow: 0px 2px 8px rgba(9, 22, 29, 0.16);
+  box-shadow: 0px 2px 8px fade(@dark-2, 16%);
   border-radius: 8px;
   display: flex;
   justify-content: space-between;
@@ -44,7 +52,7 @@ export default class BannerIntroduction extends Vue {
     font-style: normal;
     font-weight: normal;
     line-height: 130%;
-    color: @white !important;
+    color: @white;
   }
 
   &__title {

--- a/src/components/BannerIntroduction.vue
+++ b/src/components/BannerIntroduction.vue
@@ -1,0 +1,65 @@
+<template>
+  <div class="s-banner-introduction" :style="{ 'background-color': bgColor }">
+    <slot name="bgImage" />
+    <div class="s-banner-introduction__body">
+      <h2 class="s-banner-introduction__title">
+        <slot name="title" />
+      </h2>
+      <p class="s-banner-introduction__description">
+        <slot name="description" />
+      </p>
+    </div>
+    <div class="s-banner-introduction__button">
+      <slot name="button" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from "vue-property-decorator";
+
+@Component({})
+export default class BannerIntroduction extends Vue {
+  @Prop(String)
+  bgColor!: string;
+}
+</script>
+
+<style lang="less">
+@import (reference) "./../styles/Imports";
+
+.s-banner-introduction {
+  box-shadow: 0px 2px 8px rgba(9, 22, 29, 0.16);
+  border-radius: 8px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  position: relative;
+
+  &__title,
+  &__description {
+    margin: 0;
+    font-family: Roboto;
+    font-style: normal;
+    font-weight: normal;
+    line-height: 130%;
+    color: @white !important;
+  }
+
+  &__title {
+    font-size: 16px;
+  }
+
+  &__description {
+    .margin-top();
+    font-size: 14px;
+  }
+
+  &__button {
+    button {
+      cursor: pointer;
+    }
+  }
+}
+</style>

--- a/src/demos/Banners.vue
+++ b/src/demos/Banners.vue
@@ -1,373 +1,421 @@
 <template>
   <div>
     <h1>Banners</h1>
-    <TabsNew :tabs="tabs" :update-route="false" :selected="selectedTab">
-      <div slot="marketing">
-        <h2>Marketing Banner</h2>
-        <DemoSection title="Marketing Banner" :code="demoCode">
-          <template #components>
-            <banner-marketing
-              bg-image="
+    <div class="section">
+      <h2>Marketing Banner</h2>
+      <DemoSection title="Marketing Banner" :code="demoCode">
+        <template #components>
+          <banner-marketing
+            bg-image="
                 https://cdn.streamlabs.com/static/imgs/pretzel_dashboard_banner_bg.png
               "
-              bg-image-night="
+            bg-image-night="
                 http://cdn.backgroundhost.com/backgrounds/subtlepatterns/cartographer.png
               "
-              icon-name="themes"
-              label="Introducing Streamlabs OBS"
-              title="Largest library of free themes in the world."
-              desc="
+            icon-name="themes"
+            label="Introducing Streamlabs OBS"
+            title="Largest library of free themes in the world."
+            desc="
                 To access over 700+ themes for free, download Streamlabs OBS.
               "
-              link-desc="Win 7+  245.8 MB"
-              :onToggle="test"
-            >
-              <Button
-                slot="link"
-                type="a"
-                variation="action"
-                size="standard"
-                href="#"
-                title="Download"
-                icon="overview"
-              />
-            </banner-marketing>
-          </template>
-        </DemoSection>
+            link-desc="Win 7+  245.8 MB"
+            :onToggle="test"
+          >
+            <Button
+              slot="link"
+              type="a"
+              variation="action"
+              size="standard"
+              href="#"
+              title="Download"
+              icon="overview"
+            />
+          </banner-marketing>
+        </template>
+      </DemoSection>
 
-        <banner-marketing
-          bg-image="
+      <banner-marketing
+        bg-image="
             https://cdn.streamlabs.com/static/imgs/pretzel_dashboard_banner_bg.png
           "
-          icon-image="require(../assets/imgs/pretzel-icon.png)"
-          label="New Streamlabs OBS App"
-          title="Introducing Pretzel Rocks Music Player"
-          desc="
+        icon-image="require(../assets/imgs/pretzel-icon.png)"
+        label="New Streamlabs OBS App"
+        title="Introducing Pretzel Rocks Music Player"
+        desc="
             Stream-safe music for broadcasters with an ever-growing catalog of music. Currently 5k+ tracks.
           "
-          link-desc="$4.99/mo"
-          :banner-closed="bannerClosed"
-        >
-          <Button
-            slot="link"
-            type="a"
-            variation="action"
-            size="standard"
-            href="#"
-            title="Try It Now"
+        link-desc="$4.99/mo"
+        :banner-closed="bannerClosed"
+      >
+        <Button
+          slot="link"
+          type="a"
+          variation="action"
+          size="standard"
+          href="#"
+          title="Try It Now"
+        />
+      </banner-marketing>
+
+      <table class="docs-table">
+        <thead>
+          <tr>
+            <th>Prop</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Default</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>bgImage</td>
+            <td>string</td>
+            <td>true</td>
+            <td>null</td>
+            <td>Background image that will display in day mode.</td>
+          </tr>
+          <tr>
+            <td>bgImageNight</td>
+            <td>string</td>
+            <td>false</td>
+            <td>null</td>
+            <td>Background image that will display in night mode.</td>
+          </tr>
+          <tr>
+            <td>label</td>
+            <td>string</td>
+            <td>true</td>
+            <td>null</td>
+            <td>Label text in the upper left of the banner.</td>
+          </tr>
+          <tr>
+            <td>iconImage</td>
+            <td>string</td>
+            <td>false</td>
+            <td>null</td>
+            <td>
+              Icon image next to title. Use a url path. If using iconName - do
+              not use iconImg. We will improve functionality in near future.
+            </td>
+          </tr>
+          <tr>
+            <td>iconName</td>
+            <td>string</td>
+            <td>false</td>
+            <td>null</td>
+            <td>
+              Icon next to title. Use icon name from icon list. If using iconImg
+              - do not use iconName. We will improve functionality in near
+              future.
+            </td>
+          </tr>
+          <tr>
+            <td>title</td>
+            <td>string</td>
+            <td>true</td>
+            <td>null</td>
+            <td>Main banner title.</td>
+          </tr>
+          <tr>
+            <td>desc</td>
+            <td>string</td>
+            <td>true</td>
+            <td>null</td>
+            <td>Description text below banner title.</td>
+          </tr>
+          <tr>
+            <td>linkDesc</td>
+            <td>string</td>
+            <td>false</td>
+            <td>null</td>
+            <td>Description text below link.</td>
+          </tr>
+          <tr>
+            <td>bannerClosed</td>
+            <td>boolean</td>
+            <td>false</td>
+            <td>false</td>
+            <td>Default state the banner is. Open by default.</td>
+          </tr>
+          <tr>
+            <td>onToggle</td>
+            <td>function</td>
+            <td>null</td>
+            <td>false</td>
+            <td>Function which is called when you toggle the icon close.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="section">
+      <h2>Sale Banner</h2>
+      <DemoSection title="Sale Banner" :code="demoCode">
+        <template #components>
+          <banner-sale
+            title="Flash Sale! 25% off everything!"
+            desc="All items are automatically discounted."
+            days="00"
+            hours="00"
+            minutes="00"
+            :seconds="secs"
+            time-desc="Until flash sale ends. Hurry!"
           />
-        </banner-marketing>
+        </template>
+      </DemoSection>
 
-        <table class="docs-table">
-          <thead>
-            <tr>
-              <th>Prop</th>
-              <th>Type</th>
-              <th>Required</th>
-              <th>Default</th>
-              <th>Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>bgImage</td>
-              <td>string</td>
-              <td>true</td>
-              <td>null</td>
-              <td>Background image that will display in day mode.</td>
-            </tr>
-            <tr>
-              <td>bgImageNight</td>
-              <td>string</td>
-              <td>false</td>
-              <td>null</td>
-              <td>Background image that will display in night mode.</td>
-            </tr>
-            <tr>
-              <td>label</td>
-              <td>string</td>
-              <td>true</td>
-              <td>null</td>
-              <td>Label text in the upper left of the banner.</td>
-            </tr>
-            <tr>
-              <td>iconImage</td>
-              <td>string</td>
-              <td>false</td>
-              <td>null</td>
-              <td>
-                Icon image next to title. Use a url path. If using iconName - do
-                not use iconImg. We will improve functionality in near future.
-              </td>
-            </tr>
-            <tr>
-              <td>iconName</td>
-              <td>string</td>
-              <td>false</td>
-              <td>null</td>
-              <td>
-                Icon next to title. Use icon name from icon list. If using
-                iconImg - do not use iconName. We will improve functionality in
-                near future.
-              </td>
-            </tr>
-            <tr>
-              <td>title</td>
-              <td>string</td>
-              <td>true</td>
-              <td>null</td>
-              <td>Main banner title.</td>
-            </tr>
-            <tr>
-              <td>desc</td>
-              <td>string</td>
-              <td>true</td>
-              <td>null</td>
-              <td>Description text below banner title.</td>
-            </tr>
-            <tr>
-              <td>linkDesc</td>
-              <td>string</td>
-              <td>false</td>
-              <td>null</td>
-              <td>Description text below link.</td>
-            </tr>
-            <tr>
-              <td>bannerClosed</td>
-              <td>boolean</td>
-              <td>false</td>
-              <td>false</td>
-              <td>Default state the banner is. Open by default.</td>
-            </tr>
-            <tr>
-              <td>onToggle</td>
-              <td>function</td>
-              <td>null</td>
-              <td>false</td>
-              <td>Function which is called when you toggle the icon close.</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+      <table class="docs-table">
+        <thead>
+          <tr>
+            <th>Prop</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Default</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>title</td>
+            <td>string</td>
+            <td>true</td>
+            <td>null</td>
+            <td>Banner main title.</td>
+          </tr>
+          <tr>
+            <td>desc</td>
+            <td>string</td>
+            <td>true</td>
+            <td>null</td>
+            <td>Banner description text below main title.</td>
+          </tr>
+          <tr>
+            <td>days</td>
+            <td>string</td>
+            <td>true</td>
+            <td>"00"</td>
+            <td>Days remaining value for countdown timer</td>
+          </tr>
+          <tr>
+            <td>hours</td>
+            <td>string</td>
+            <td>true</td>
+            <td>"00"</td>
+            <td>Hours remaining value for countdown timer</td>
+          </tr>
+          <tr>
+            <td>minutes</td>
+            <td>string</td>
+            <td>true</td>
+            <td>"00"</td>
+            <td>Minutes remaining value for countdown timer</td>
+          </tr>
+          <tr>
+            <td>seconds</td>
+            <td>string</td>
+            <td>true</td>
+            <td>"00"</td>
+            <td>Seconds remaining value for countdown timer</td>
+          </tr>
+          <tr>
+            <td>timeDesc</td>
+            <td>string</td>
+            <td>false</td>
+            <td>null</td>
+            <td>Description text below countdown timer.</td>
+          </tr>
+          <tr>
+            <td>borderColor</td>
+            <td>string</td>
+            <td>false</td>
+            <td>"rgba(248, 86, 64, 0.33)"</td>
+            <td>Banner border color.</td>
+          </tr>
+          <tr>
+            <td>backgroundColor</td>
+            <td>boolean</td>
+            <td>false</td>
+            <td>"rgba(248, 86, 64, 0.08)"</td>
+            <td>Banner background color.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 
-      <div slot="sale">
-        <h2>Sale Banner</h2>
-        <DemoSection title="Sale Banner" :code="demoCode">
-          <template #components>
-            <banner-sale
-              title="Flash Sale! 25% off everything!"
-              desc="All items are automatically discounted."
-              days="00"
-              hours="00"
-              minutes="00"
-              :seconds="secs"
-              time-desc="Until flash sale ends. Hurry!"
-            />
-          </template>
-        </DemoSection>
-
-        <table class="docs-table">
-          <thead>
-            <tr>
-              <th>Prop</th>
-              <th>Type</th>
-              <th>Required</th>
-              <th>Default</th>
-              <th>Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>title</td>
-              <td>string</td>
-              <td>true</td>
-              <td>null</td>
-              <td>Banner main title.</td>
-            </tr>
-            <tr>
-              <td>desc</td>
-              <td>string</td>
-              <td>true</td>
-              <td>null</td>
-              <td>Banner description text below main title.</td>
-            </tr>
-            <tr>
-              <td>days</td>
-              <td>string</td>
-              <td>true</td>
-              <td>"00"</td>
-              <td>Days remaining value for countdown timer</td>
-            </tr>
-            <tr>
-              <td>hours</td>
-              <td>string</td>
-              <td>true</td>
-              <td>"00"</td>
-              <td>Hours remaining value for countdown timer</td>
-            </tr>
-            <tr>
-              <td>minutes</td>
-              <td>string</td>
-              <td>true</td>
-              <td>"00"</td>
-              <td>Minutes remaining value for countdown timer</td>
-            </tr>
-            <tr>
-              <td>seconds</td>
-              <td>string</td>
-              <td>true</td>
-              <td>"00"</td>
-              <td>Seconds remaining value for countdown timer</td>
-            </tr>
-            <tr>
-              <td>timeDesc</td>
-              <td>string</td>
-              <td>false</td>
-              <td>null</td>
-              <td>Description text below countdown timer.</td>
-            </tr>
-            <tr>
-              <td>borderColor</td>
-              <td>string</td>
-              <td>false</td>
-              <td>"rgba(248, 86, 64, 0.33)"</td>
-              <td>Banner border color.</td>
-            </tr>
-            <tr>
-              <td>backgroundColor</td>
-              <td>boolean</td>
-              <td>false</td>
-              <td>"rgba(248, 86, 64, 0.08)"</td>
-              <td>Banner background color.</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <div slot="notice">
-        <h2>Notice Banner</h2>
-        <DemoSection title="Notice Banner" :code="demoCode">
-          <template #components>
-            <Notice
-              title="
+    <div class="section">
+      <h2>Notice Banner</h2>
+      <DemoSection title="Notice Banner" :code="demoCode">
+        <template #components>
+          <Notice
+            title="
                 Join affiliates and earn $1 for each Streamlabs OBS referral
               "
-              desc="
+            desc="
                 Share your unique referral link with friends and get paid directly into your PayPal each month.
               "
-              icon="information"
+            icon="information"
+          >
+            <Button
+              slot="button"
+              type="button"
+              size="fixed-width"
+              variation="action"
+              title="Join"
+            />
+          </Notice>
+        </template>
+      </DemoSection>
+
+      <br />
+      <br />
+
+      <Notice
+        variation="warning"
+        title="Your donation link has expired"
+        desc="Copy your new donation link and replace all instances containing twitchalerts.com."
+      >
+        <Button
+          slot="button"
+          type="button"
+          size="fixed-width"
+          variation="default"
+          title="Copy Link"
+        />
+      </Notice>
+
+      <table class="docs-table">
+        <thead>
+          <tr>
+            <th>Prop</th>
+            <th>Type</th>
+            <th>Required</th>
+            <th>Default</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>variation</td>
+            <td>string</td>
+            <td>true</td>
+            <td>default</td>
+            <td>
+              Variation style that will be displayed. Options are "default" and
+              "warning".
+            </td>
+          </tr>
+          <tr>
+            <td>title</td>
+            <td>string</td>
+            <td>true</td>
+            <td>null</td>
+            <td>Banner title</td>
+          </tr>
+          <tr>
+            <td>desc</td>
+            <td>string</td>
+            <td>true</td>
+            <td>null</td>
+            <td>Description text below banner title</td>
+          </tr>
+          <tr>
+            <td>icon</td>
+            <td>string</td>
+            <td>true</td>
+            <td>null</td>
+            <td>
+              Icon next to title and in background. Will override selected
+              variation icon. Use icon name from icon list.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="section">
+      <h2>Discord Banner</h2>
+      <DemoSection title="Discord Banner" :code="demoCode">
+        <template #components>
+          <BannerDiscord />
+        </template>
+      </DemoSection>
+
+      <table class="docs-table">
+        <thead>
+          <tr>
+            <th>Prop</th>
+            <th>Type</th>
+            <th>Default</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>title</td>
+            <td>string</td>
+            <td>
+              Join the Streamlabs OBS Discussion on
+              &lt;span&gt;Discord&lt;/span&gt;
+            </td>
+            <td>
+              Set the title of the banner. You can wrap text in
+              <code>&lt;span&gt;</code> tags to give them medium font weight.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="section">
+      <h2>Introduction Banner</h2>
+      <DemoSection title="Introduction Banner" :code="demoCode">
+        <template #components>
+          <BannerIntroduction bgColor="#5e3bec">
+            <img
+              slot="bgImage"
+              src="https://cdn.streamlabs.com/static/alert-box-sounds-banner-bg.png"
+              alt=""
+              class="banner-introduction-bgImage"
+            />
+            <template #title
+              >Introducing<span class="banner-introduction-title"
+                >Prime Alert Box Sounds</span
+              ></template
             >
-              <Button
-                slot="button"
-                type="button"
-                size="fixed-width"
-                variation="action"
-                title="Join"
-              />
-            </Notice>
-          </template>
-        </DemoSection>
+            <template #description
+              >Modern, hype sounds you can add to your live alerts. All included
+              with Prime.</template
+            >
+            <Button
+              slot="button"
+              title="Browse Sounds"
+              :bgColor="'#000'"
+              :textColor="'#fff'"
+            ></Button>
+          </BannerIntroduction>
+        </template>
+      </DemoSection>
 
-        <br />
-        <br />
-
-        <Notice
-          variation="warning"
-          title="Your donation link has expired"
-          desc="Copy your new donation link and replace all instances containing twitchalerts.com."
-        >
-          <Button
-            slot="button"
-            type="button"
-            size="fixed-width"
-            variation="default"
-            title="Copy Link"
-          />
-        </Notice>
-
-        <table class="docs-table">
-          <thead>
-            <tr>
-              <th>Prop</th>
-              <th>Type</th>
-              <th>Required</th>
-              <th>Default</th>
-              <th>Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>variation</td>
-              <td>string</td>
-              <td>true</td>
-              <td>default</td>
-              <td>
-                Variation style that will be displayed. Options are "default"
-                and "warning".
-              </td>
-            </tr>
-            <tr>
-              <td>title</td>
-              <td>string</td>
-              <td>true</td>
-              <td>null</td>
-              <td>Banner title</td>
-            </tr>
-            <tr>
-              <td>desc</td>
-              <td>string</td>
-              <td>true</td>
-              <td>null</td>
-              <td>Description text below banner title</td>
-            </tr>
-            <tr>
-              <td>icon</td>
-              <td>string</td>
-              <td>true</td>
-              <td>null</td>
-              <td>
-                Icon next to title and in background. Will override selected
-                variation icon. Use icon name from icon list.
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <div slot="discord">
-        <h2>Discord Banner</h2>
-        <DemoSection title="Discord Banner" :code="demoCode">
-          <template #components>
-            <BannerDiscord />
-          </template>
-        </DemoSection>
-
-        <table class="docs-table">
-          <thead>
-            <tr>
-              <th>Prop</th>
-              <th>Type</th>
-              <th>Default</th>
-              <th>Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>title</td>
-              <td>string</td>
-              <td>
-                Join the Streamlabs OBS Discussion on
-                &lt;span&gt;Discord&lt;/span&gt;
-              </td>
-              <td>
-                Set the title of the banner. You can wrap text in
-                <code>&lt;span&gt;</code> tags to give them medium font weight.
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </TabsNew>
+      <table class="docs-table">
+        <thead>
+          <tr>
+            <th>Prop</th>
+            <th>Type</th>
+            <th>Default</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>bgColor</td>
+            <td>string</td>
+            <td>Null</td>
+            <td>Set the background color of the banner.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </template>
 
@@ -375,48 +423,27 @@
 import { Component, Vue } from "vue-property-decorator";
 import BannersCode from "!!raw-loader!./Banners.vue";
 import BannerDiscord from "./../components/BannerDiscord.vue";
+import BannerIntroduction from "./../components/BannerIntroduction.vue";
 import BannerMarketing from "./../components/BannerMarketing.vue";
 import BannerSale from "./../components/BannerSale.vue";
 import Button from "./../components/Button.vue";
 import DemoSection from "./../components/DemoSection.vue";
 import Notice from "./../components/Notice.vue";
-import Tabs from "./../components/Tabs.vue";
-import TabsNew from "./../components/TabsNew.vue";
 
 @Component({
   components: {
     BannerDiscord,
+    BannerIntroduction,
     BannerMarketing,
     BannerSale,
     Button,
     DemoSection,
     Notice,
-    Tabs,
-    TabsNew
-  }
+  },
 })
 export default class Banners extends Vue {
   demoCode = BannersCode;
-  tabs = [
-    {
-      name: "Marketing",
-      value: "marketing"
-    },
-    {
-      name: "Sale",
-      value: "sale"
-    },
-    {
-      name: "Notice",
-      value: "notice"
-    },
-    {
-      name: "Discord",
-      value: "discord"
-    }
-  ];
 
-  selectedTab = "marketing";
   remainingSecs = 10;
 
   bannerClosed = false;
@@ -430,10 +457,6 @@ export default class Banners extends Vue {
     }, 1000);
   }
 
-  onSelectTabHandler(tab: string) {
-    this.selectedTab = tab;
-  }
-
   get secs() {
     return this.remainingSecs < 10
       ? `0${this.remainingSecs}`
@@ -445,3 +468,18 @@ export default class Banners extends Vue {
   }
 }
 </script>
+
+<style lang="less" scoped>
+.banner-introduction-title {
+  font-weight: 500;
+  padding: 0 8px;
+}
+
+.banner-introduction-bgImage {
+  position: absolute;
+  width: auto;
+  height: 100%;
+  right: 0px;
+  border-radius: 8px;
+}
+</style>

--- a/src/system.js
+++ b/src/system.js
@@ -8,6 +8,7 @@
 import Accordion from "./components/Accordion.vue";
 import Badge from "./components/Badge.vue";
 import BannerDiscord from "./components/BannerDiscord.vue";
+import BannerIntroduction from "./components/BannerIntroduction.vue";
 import BannerMarketing from "./components/BannerMarketing.vue";
 import Button from "./components/Button.vue";
 import CallToAction from "./components/CallToAction.vue";
@@ -69,6 +70,7 @@ export {
   Accordion,
   Badge,
   BannerDiscord,
+  BannerIntroduction,
   BannerMarketing,
   Button,
   CallToAction,


### PR DESCRIPTION
Naming slot is applied in most of the parts since slot is more reusable,
customizable than prop. And all of the elements are optional including
background image.

Also, banners are listed on the same view now instead of using tabs. No
need to use tabs for only displaying a few banners each tab.

figma: https://www.figma.com/file/qQuwhCydVZXKty1fD1HNDK/prime-mb?node-id=383%3A168