### PR TITLE
mini color pickers build out

### DIFF
--- a/src/components/ColorPicker.vue
+++ b/src/components/ColorPicker.vue
@@ -1,6 +1,14 @@
 <template>
-  <div class="s-colorpicker-container" ref="colorpicker">
+  <div
+    class="s-colorpicker-container"
+    ref="colorpicker"
+    :class="{
+      's-colorpicker-container__mini': isMini,
+      's-colorpicker-container__mini-icon': isMini && icon
+    }"
+  >
     <input
+      v-if="!isMini"
       type="text"
       :value="value"
       :placeholder="placeholder"
@@ -9,6 +17,16 @@
       v-on="listeners"
       :class="{ 's-colorpicker__input--error': error }"
     />
+
+    <div
+      class="s-colorpicker__mini-wrapper"
+      v-if="isMini"
+      @click="showPicker()"
+      :class="{ 's-colorpicker__input--error': error }"
+    >
+      <i :class="icon"></i>
+    </div>
+
     <div v-if="error" class="s-colorpicker__input-error">
       <i class="icon-error"></i>
       {{ error }}
@@ -22,15 +40,26 @@
     <div class="s-colorpicker__preview--alpha"></div>
 
     <transition name="fade">
-      <picker
-        class="s-colorpicker"
-        :class="alphaClass"
-        :value="colors"
-        v-if="displayPicker"
-        :disable-alpha="!hasAlpha"
-        :disable-fields="!hasAlpha"
-        @input="updateFromPicker"
-      />
+      <div v-if="displayPicker" style="display: block;">
+        <picker
+          class="s-colorpicker"
+          :class="alphaClass"
+          :value="colors"
+          :disable-alpha="!hasAlpha"
+          :disable-fields="!hasAlpha"
+          @input="updateFromPicker"
+        />
+        <input
+          v-if="isMini"
+          type="text"
+          :value="value"
+          :placeholder="placeholder"
+          @input="updateFromInput"
+          v-on="$listeners"
+          class="s-colorpicker__input--mini"
+          :class="{ 's-colorpicker__input--error': error }"
+        />
+      </div>
     </transition>
   </div>
 </template>
@@ -69,6 +98,12 @@ export default class ColorPicker extends Vue {
 
   @Prop({ default: false })
   hasAlpha!: boolean;
+
+  @Prop({ default: false })
+  isMini!: boolean;
+
+  @Prop()
+  icon!: string;
 
   @Prop()
   error!: string;
@@ -145,6 +180,35 @@ export default class ColorPicker extends Vue {
     position: relative;
     display: inline-block;
     width: 225px;
+    &__mini {
+      width: 38px;
+    }
+    &__mini-icon {
+      width: 70px;
+    }
+  }
+
+  &__input {
+    &--mini {
+      width: 225px !important;
+    }
+  }
+
+  &__mini-wrapper {
+    border: 1px solid black;
+    border-color: #4f5e65;
+    background: transparent;
+    color: #ffffff;
+    height: 40px;
+    border-radius: 4px;
+    font-family: "Roboto";
+    font-size: 14px;
+    i {
+      position: absolute;
+      top: 12px;
+      left: 10px;
+      z-index: 1;
+    }
   }
 
   &__preview {

--- a/src/demos/ColorPickers.vue
+++ b/src/demos/ColorPickers.vue
@@ -36,6 +36,28 @@ components: {
         </DemoSection>
       </div>
 
+      <div class="section">
+        <h3>Mini, with hex code selector</h3>
+        <DemoSection title="Mini" :code="demoCode">
+          <template #components>
+            <ColorPicker :isMini="true" v-model="miniColor" />
+          </template>
+        </DemoSection>
+      </div>
+
+      <div class="section">
+        <h3>Mini, with icon (optional)</h3>
+        <DemoSection title="MiniIcon" :code="demoCode">
+          <template #components>
+            <ColorPicker
+              icon="icon-text"
+              :isMini="true"
+              v-model="miniIconColor"
+            />
+          </template>
+        </DemoSection>
+      </div>
+
       <table class="docs-table">
         <thead>
           <tr>
@@ -96,6 +118,8 @@ export default class ColorPickers extends Vue {
   demoCode = ColorPickersCode;
   color = "#5E3BEC";
   alphaColor = "#EB7777";
+  miniColor = "#5E3BEC";
+  miniIconColor = "#5E3BEC";
 
   setAlphaColor(color) {
     this.alphaColor = color.hex || color;


### PR DESCRIPTION
for Melon, we need more customizability for the color pickers -- we are introducing a mini version, with a hex code picker as part of the dropdown. icon optional!

<img width="321" alt="Screen Shot 2022-08-29 at 4 42 18 PM" src="https://user-images.githubusercontent.com/55334682/187295103-131446d5-e19b-4949-863a-3e2fba26d8d0.png">
